### PR TITLE
ci: add ios-release action

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,42 @@
+name: IOS - Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to deploy"
+        required: true
+        default: appetize
+        type: choice
+        options:
+          - appetize
+          - testflight
+
+jobs:
+  call_get_vars:
+    uses: ./.github/workflows/get-vars.yml  
+
+  ios_build:
+    needs: call_get_vars
+    # Calls the reusable workflow from the actions repo
+    uses: IDEMSInternational/open-app-builder-actions/.github/workflows/ios-release.yml@main
+    with:
+      target: ${{ github.event.inputs.target }} # "appetize" or "testflight"
+      CONTENT_BRANCH: ""
+      APP_CODE_BRANCH: ${{ vars.APP_CODE_BRANCH }}
+      LFS_USED: ${{ needs.call_get_vars.outputs.LFS_USED == 'true' }}
+      DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_NAME: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_NAME }}
+      PARENT_DEPLOYMENT_REPO: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_REPO }}
+      PARENT_DEPLOYMENT_BRANCH: ${{ needs.call_get_vars.outputs.PARENT_DEPLOYMENT_BRANCH }}
+      ENCRYPTED: ${{ needs.call_get_vars.outputs.ENCRYPTED == 'true' }}
+    secrets:
+      DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}
+      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+      GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+      GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_IOS_CERTS_SERVICE_ACCOUNT_KEY }}
+      GCP_IOS_CERTS_ENCRYPTION_PASSWORD: ${{ secrets.GCP_IOS_CERTS_ENCRYPTION_PASSWORD }}
+      APPETIZE_TOKEN: ${{ secrets.APPETIZE_TOKEN }}


### PR DESCRIPTION
Adds ios-release action from https://github.com/IDEMSInternational/open-app-builder-actions/blob/main/content_repository_actions/ios-release.yml to enable triggering automated iOS releases