### PR TITLE
chore: bump version number to 1.2.3

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ const config = generateDeploymentConfig("plh_kids_teens_pa");
 
 config.git = {
   content_repo: "https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content.git",
-  content_tag_latest: "1.2.2",
+  content_tag_latest: "1.2.3",
 };
 
 config.google_drive.sheets_folders = [


### PR DESCRIPTION
Increase patch version number, no other changes. Required in order to re-release to Apple